### PR TITLE
Add process updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ For minor issues like bug fixes or small enhancements, please use the appropriat
 
 The RFC process has the following states:
 
-1. **Draft**: The RFC is under initial discussion and may undergo several revisions.
-2. **FCP (Final Comment Period)**: ALESCo announces an FCP, signaling that the decision will be made soon.
+0. **Submitted**: The RFC is submitted and requires an initial review for formatting, etc. Once it has been confirmed to meet the needs of the RFC process, the "accepted for discussion" tag will be added.
+1. **Open for discussion**: The RFC is under initial and active discussion and may undergo several revisions.
+2. **FCP (Final Comment Period)**: ALESCo announces an FCP, signaling that the decision will be made soon. When the RFC enters this stage, the "vote at next meeting" tag will be added.
 3. **Accepted**: The RFC is approved and merged.
 4. **Rejected**: The RFC is not approved; reasons are documented.
 5. **Withdrawn**: The RFC is withdrawn by the author.
@@ -95,13 +96,13 @@ By contributing to this repository, you agree that your contributions will be li
 
 ## Contact
 
-* **Mailing List:** [devel@lists.almalinux.org](https://lists.almalinux.org/mailman3/lists/devel.lists.almalinux.org/)
+* **Chat:** [AlmaLinux MatterMost](https://chat.almalinux.org/~alesco)
 * **Forums:** [AlmaLinux Community Forums](https://forums.almalinux.org/)
-* **Chat:** [AlmaLinux MatterMost](https://chat.almalinux.org)
+* **Mailing List:** [devel@lists.almalinux.org](https://lists.almalinux.org/mailman3/lists/devel.lists.almalinux.org/)
 
 # Additional Notes
 
-* **Assigning RFC Numbers:** RFC numbers are assigned by the repository maintainers when the pull request is labeled as "Ready for Review." Use 0000 as the number in your initial submission.
+* **Assigning RFC Numbers:** RFC numbers are assigned by the repository maintainers when the pull request is labeled as "accepted for discussion." Use 0000 as the number in your initial submission.
 * **File Naming Convention:** Name your RFC file as XXXX-title-of-your-proposal.md, where XXXX is the assigned RFC number.
 * **Directory Structure:** All RFC files should be placed in the rfcs/ directory.
 * **Updating RFC Status:** The status of the RFC should be updated in the document header as it progresses through the lifecycle stages.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For minor issues like bug fixes or small enhancements, please use the appropriat
 
 ## AlmaLinux OS Foundation Board input as a blocker
 
-In very rare circumstances the AlmaLinux OS Foundation Board will be required to provide input in things ALESCo is deciding on. In some cases the board may be required to approve a change, and in some cases they can abstain from an official position. However, as part of their oversite in the project, input will be required before a vote can be held in the following situations.
+In very rare circumstances the AlmaLinux OS Foundation Board will be required to provide input in things ALESCo is deciding on. In some cases the board may be required to approve a change, and in some cases they can abstain from an official position. However, as part of their oversight in the project, input will be required before a vote can be held in the following situations.
 
 * Input from the board will be a blocking stakeholder before ALESCo can vote on RFCs that...
    - involve a change to trademarks 
@@ -109,7 +109,7 @@ By contributing to this repository, you agree that your contributions will be li
 
 ## Contact
 
-* **Chat:** [AlmaLinux MatterMost](https://chat.almalinux.org/~alesco)
+* **Chat:** [AlmaLinux Mattermost](https://chat.almalinux.org/~alesco)
 * **Forums:** [AlmaLinux Community Forums](https://forums.almalinux.org/)
 * **Mailing List:** [devel@lists.almalinux.org](https://lists.almalinux.org/mailman3/lists/devel.lists.almalinux.org/)
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ For minor issues like bug fixes or small enhancements, please use the appropriat
 
 1. **Proposal Drafting**: Author drafts the RFC using the provided template.
 2. **Submission**: RFC is submitted as a pull request to this repository.
-3. **Public Discussion**: Community and ALESCo members provide feedback.
-4. **Review Period**: A designated period for discussion and revisions.
-5. **Final Comment Period (FCP)**: A last call for comments before the decision.
-6. **Decision Making**: ALESCo reviews and votes on the RFC.
+3. **Accepted for Discussion**: Community and ALESCo members provide feedback, with active revision of the proposal expected. 
+	As part of this step, ALESCo will also send an email to the AlmaLinux OS Foundation board with a link to the RFC pull request, indicating whether or not the board input is expected to be a blocker for the vote.
+5. **Final Comment Period (FCP)**: A last call for comments before the decision. The board will also get a notification of an impending vote here, in case they would like to provide input.
+6. **Decision Making**: ALESCo votes on the RFC.
 7. **Implementation**: Accepted RFCs are merged and scheduled for implementation.
 
 ## How to Submit an RFC

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ For minor issues like bug fixes or small enhancements, please use the appropriat
 6. **Decision Making**: ALESCo votes on the RFC.
 7. **Implementation**: Accepted RFCs are merged and scheduled for implementation.
 
+## AlmaLinux OS Foundation Board input as a blocker
+
+In very rare circumstances the AlmaLinux OS Foundation Board will be required to provide input in things ALESCo is deciding on. In some cases the board may be required to approve a change, and in some cases they can abstain from an official position. However, as part of their oversite in the project, input will be required before a vote can be held in the following situations.
+
+* Input from the board will be a blocking stakeholder before ALESCo can vote on RFCs that...
+   - involve a change to trademarks 
+   - involve a significant increase in needed resources
+   - involve a new or expanded partnership of some kind
+
+To ensure the board provides input, the current board chair will be added as a required reviewer to the pull request. A representative from the board will also attend the meeting where the vote is taking place.
+
+As a note - this is not a veto right, but is only to ensure that the board has been able to advise ALESCo on any potential impacts of changes. 
+
 ## How to Submit an RFC
 
 1. **Fork the Repository**: Click the "Fork" button at the top-right corner of this page to create your own copy of the repository.


### PR DESCRIPTION
I'm not sure this is exactly the right place for this, but I wanted to make sure it didn't get lost in chat, and it involves some process changes so 

At the leadership summit in January we discussed adding more process around the management of new proposals so that the board could be aware (even if they aren't a blocker in any way). We also discussed a few situations in which the board's input should be a blocker to a vote. 

This is some of the things that were discussed, and could be adopted. How we implement these (or whatever we land on) so that the board can be aware of things as they are relevant can be defined as we go forward. 

Summary: 

* adjusted the language in the `RFC Lifecycle` section to match the `RFC Process Overview` section.
* added the label additions that we discussed in chat
* moved the chat to the top of the list for discussion, since that's where the most engagement happens
* added notes about when/where the board should be notified
* added a note about when/where input from the board would be a voting blocker