### PR TITLE
Add new member procedure document

### DIFF
--- a/new-member-procedures.md
+++ b/new-member-procedures.md
@@ -1,0 +1,76 @@
+---
+Title: 'ALESCo New Member Procedure'
+---
+
+# Adding New Members to ALESCo
+
+This document describes the procedure ALESCo follows when appointing a new member to the committee, either to fill a vacancy arising from a member's resignation or to expand the committee's membership.
+
+The initial ALESCo membership was appointed by the AlmaLinux OS Foundation Board of Directors. After that initial appointment, ALESCo manages its own membership and follows the procedure below for every subsequent appointment.
+
+## Eligibility
+
+A candidate for ALESCo membership must:
+
+* Be an active member of the AlmaLinux community.
+* Have, and be prepared to maintain, relevant knowledge and understanding of the technical aspects of AlmaLinux as well as the greater enterprise Linux and open source ecosystems, so that they can make informed decisions in policy creation and voting.
+* Be willing to publicly disclose their employer and any conflicts of interest, in line with ALESCo's general policies.
+
+## Procedure
+
+1. **Nomination.** A candidate must first be nominated by a current, acting member of ALESCo. Self-nominations are not accepted; the candidate must be put forward by an existing committee member.
+
+2. **Questionnaire.** Once nominated, the candidate completes a questionnaire provided by ALESCo. The questionnaire is intended to help the committee make an informed and balanced decision by understanding the candidate's background, qualifications, professional activities, contributions to the AlmaLinux project, and motivation for joining ALESCo.
+
+3. **Review Period.** The completed questionnaire must be distributed to all ALESCo members at least **5 business days before the vote**, to give every member adequate time to review the candidate's responses and ask follow-up questions.
+
+4. **Vote.** The appointment of a new member requires approval by a **simple majority vote** of the current ALESCo members. The vote is conducted as a Roll Call Vote following the procedures defined in the [ALESCo Voting Policy](./voting-procedures.md). Quorum requirements (50% of members + 1, with a minimum of four members) apply.
+
+5. **Confirmation.** Following successful approval, the candidate is invited to the next ALESCo meeting, where they will formally confirm their acceptance to join the committee. Upon confirmation, they take their seat as a full voting member.
+
+## Questionnaire
+
+The questionnaire sent to nominated candidates consists of the following questions:
+
+1. Are you willing to serve on the AlmaLinux Engineering Steering Committee (ALESCo)?
+2. In some cases, directors have had to clear with their HR, Legal, management, whatever, from their employer to even be considered for a seat. If this is you, and you answered yes to #1, then please start that process, so that we are not surprised later on. Let us know that you've been cleared to stand.
+3. Why do you want to be a member of ALESCo and how do you expect to help steer the direction of AlmaLinux?
+4. How do you currently contribute to AlmaLinux? How does that contribution benefit the community?
+5. How do you handle disagreements when working as part of a team?
+6. What else should community members know about you or your positions?
+
+## Example: Nominating and Appointing a New Member
+
+The following illustrates how the procedure is applied in practice.
+
+1. **Nomination at a meeting:**
+
+> Member A: "I would like to nominate Candidate X for membership on ALESCo. Candidate X has been an active AlmaLinux contributor for the past two years, and I believe their experience would be valuable to the committee."
+>
+> Chair: "Thank you, Member A. The nomination is recorded. We will send Candidate X the membership questionnaire and add the vote to a future agenda once the questionnaire has been returned and circulated for the required review period."
+
+2. **Questionnaire and review:**
+
+   * Candidate X receives and completes the questionnaire.
+   * The Chair distributes the completed questionnaire to all ALESCo members.
+   * At least five business days pass between distribution and the scheduled vote.
+
+3. **Vote at the next eligible meeting** (following the Roll Call Voting procedure):
+
+> Chair: "The voting issue before us is whether to appoint Candidate X to ALESCo. The questionnaire was circulated on [date], which is more than five business days ago, satisfying our review-period requirement."
+>
+> The Chair then lists voting members present, confirms quorum, and asks each member for a vote of "Yes", "No", or "Abstain" as described in the ALESCo Voting Policy.
+
+4. **Confirmation at the following meeting:**
+
+> Chair: "At our last meeting we voted to appoint Candidate X to ALESCo. Candidate X, do you accept the appointment?"
+>
+> Candidate X: "Yes, I accept."
+>
+> Chair: "Welcome to ALESCo. You are now a full voting member of the committee."
+
+## Term Duration
+
+ALESCo members are appointed with no set term. Every six months, at the time of the regular ALESCo Chair election, each member will be asked whether they intend to continue serving or wish to step down. This semi-annual check-in is the standard mechanism for managing the ongoing composition of the committee.
+
+A member may step down at any time outside of this check-in by notifying the Chair and the rest of the committee. When a vacancy arises — whether through stepping down or any other reason — the committee may choose to fill it by appointing a new member following the procedure above.


### PR DESCRIPTION
Adds `new-member-procedures.md` at the repo root, documenting the procedure ALESCo follows when appointing a new member. Content is drawn from the policy already merged to the ALESCo wiki (https://wiki.almalinux.org/alesco.html), supplemented by the meeting minutes that shaped it (2025-08-20, 2025-09-04, 2025-10-30, 2025-11-13, 2026-01-08).

**Is this repo the right home for this document, or should it live on the wiki instead?**

The policy itself already exists at https://wiki.almalinux.org/alesco.html under "Appointments". The version in this PR is a fuller, procedure-style write-up (with the example flow and the questionnaire text) in the same style as `voting-procedures.md`, which also lives in this repo despite related governance material being on the wiki. Happy to move this to the wiki instead — or keep it here and link to/from the wiki — based on what the rest of the committee prefers.

I'm actually thinking that we should expand the ALESCo wiki dropdown to have detail pages like this.  Maybe voting procedures should be moved there as well.